### PR TITLE
UI-1918 use reseller's own service plans

### DIFF
--- a/app.js
+++ b/app.js
@@ -535,6 +535,7 @@ define(function(require){
 
 			monster.pub('common.servicePlanDetails.getServicePlanTemplate', {
 				mode: 'new',
+				useOwnPlans: monster.apps.auth.isReseller,
 				afterRender: function(template, data) {
 					stepTemplate.find('.common-container')
 								.append(template);


### PR DESCRIPTION
Adds additional argument 'useOwnPlans', which is set to true for resellers. This allows a reseller to assign his own service plans instead of his parent's service plans. Affects only the "Add New Account" wizard.

See the corresponding pull request for the monster-ui repo (https://github.com/2600hz/monster-ui/pull/26)