### PR TITLE
MACT-30: Prepare review step for print view

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -608,6 +608,16 @@
 					}
 				}
 			},
+			"document": {
+				"header": {
+					"page": "Page:",
+					"pageOf": "{{current}} of {{total}}",
+					"date": "Issue Date:"
+				},
+				"sections": {
+					"title": "{{correlative}}. {{title}}"
+				}
+			},
 			"title": "Creating a New Account"
 		}
 	}

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -608,16 +608,6 @@
 					}
 				}
 			},
-			"document": {
-				"header": {
-					"page": "Page:",
-					"pageOf": "{{current}} of {{total}}",
-					"date": "Issue Date:"
-				},
-				"sections": {
-					"title": "{{correlative}}. {{title}}"
-				}
-			},
 			"title": "Creating a New Account"
 		}
 	}

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -292,7 +292,7 @@
 	"accountsApp": {
 		"serviceItemsListing": {
 			"columns": {
-				"item": "Service items",
+				"item": "Service Items",
 				"quantity": "Quantity",
 				"rate": "Rate",
 				"discount": "Discount"

--- a/submodules/serviceItemsListing/serviceItemsListing.scss
+++ b/submodules/serviceItemsListing/serviceItemsListing.scss
@@ -20,8 +20,9 @@
 		border-bottom: 1px solid $french-gray2;
 		line-height: 0.75rem;
 		font-size: 0.75rem;
-		font-weight: normal;
+		font-weight: 600;
 		text-align: left;
+		text-transform: uppercase;
 		color: $midgray2;
 
 		&:first-child {
@@ -44,6 +45,7 @@
 			// To override .monster-table specific style
 			&:first-child:not(.category-cell) {
 				width: 40%;
+				padding-left: 2rem;
 				border-left: none;
 			}
 

--- a/submodules/serviceItemsListing/serviceItemsListing.scss
+++ b/submodules/serviceItemsListing/serviceItemsListing.scss
@@ -54,6 +54,8 @@
 			&.category-cell {
 				width: 100%;
 				background: #dbdbde;
+				border-right: none;
+				border-left: none;
 				border-radius: 0px;
 				font-weight: 600;
 				text-align: left;

--- a/submodules/serviceItemsListing/serviceItemsListing.scss
+++ b/submodules/serviceItemsListing/serviceItemsListing.scss
@@ -7,22 +7,21 @@
 		height: auto;
 	}
 
-	th {
-		font-size: 0.75rem;
-		line-height: 0.75rem;
+	th, tbody td, tbody td:first-child {
+		padding: 0.75rem 1rem;
 	}
 
-	th, tbody td, tbody td:first-child {
-		padding: 11px 1rem;
-		line-height: 16px;
+	tbody td, tbody td:first-child {
+		line-height: 14px;
 	}
 
 	th {
 		width: 20%;
 		border-bottom: 1px solid $french-gray2;
-		text-transform: uppercase;
+		line-height: 0.75rem;
+		font-size: 0.75rem;
+		font-weight: normal;
 		text-align: left;
-		letter-spacing: 0.4px;
 		color: $midgray2;
 
 		&:first-child {
@@ -43,9 +42,8 @@
 			border-bottom-color: $french-gray2;
 
 			// To override .monster-table specific style
-			&:first-child {
+			&:first-child:not(.category-cell) {
 				width: 40%;
-				padding-left: 2rem;
 				border-left: none;
 			}
 
@@ -65,7 +63,8 @@
 	}
 
 	.iconography {
+		display: inline-block;
+		margin: -0.125rem 0 -0.125rem 0.75rem;
 		color: $midgray2;
-		margin-left: 0.75rem;
 	}
 }

--- a/submodules/wizard/views/step-review.html
+++ b/submodules/wizard/views/step-review.html
@@ -76,10 +76,7 @@
 		<div class="step-title flex-fit">
 			{{i18n.accountsApp.wizard.steps.review.title}}
 		</div>
-		<button class="step-action-button flex-initial">
-			{{telicon "download-cloud"}}
-		</button>
-		<button class="step-action-button flex-initial">
+		<button id="step_print" class="step-action-button flex-initial">
 			{{telicon "device-fax"}}
 		</button>
 	</div>

--- a/submodules/wizard/views/step-review.html
+++ b/submodules/wizard/views/step-review.html
@@ -16,7 +16,7 @@
 			{{tryI18n (lookupPath (lookupPath @root.i18n.accountsApp.wizard.steps i18nSectionName) "labels") i18nFieldName}}
 		{{/if}}
 		</div>
-		<div class="flex-item-4-3 field-value-horizontal">
+		<div class="flex-item-4-3 field-value-horizontal{{#if hasMultipleFields}} field-value-multiple{{/if}}">
 		{{#if hasContent}}	{{!-- Necessary to know if there is a @partial-block to render, and to avoid endless recursion --}}
 			{{> @partial-block value=(lookupPath this (coalesce fieldPath i18nFieldName))}}
 		{{else}}
@@ -95,7 +95,7 @@
 		{{/horizontalFieldPartial}}
 		{{> horizontalFieldPartial fieldPath="generalSettings.accountInfo.timezone" i18nSectionName="generalSettings.accountInfo" i18nFieldName="timezone"}}
 		{{> horizontalFieldPartial fieldPath="generalSettings.accountInfo.language" i18nSectionName="generalSettings.accountInfo" i18nFieldName="language"}}
-		{{#> horizontalFieldPartial label=(replaceVar i18n.accountsApp.wizard.steps.review.generalSettings.formats.accountAdminsCount generalSettings.accountAdmins.length) hasContent=true}}
+		{{#> horizontalFieldPartial label=(replaceVar i18n.accountsApp.wizard.steps.review.generalSettings.formats.accountAdminsCount generalSettings.accountAdmins.length) hasMultipleFields=true hasContent=true}}
 			{{#each generalSettings.accountAdmins}}
 				<div class="flex-row-container">
 					{{> verticalFieldPartial fieldPath="fullName" i18nSectionName="review.general" i18nFieldName="fullName"}}
@@ -136,14 +136,14 @@
 		{{> horizontalFieldPartial fieldPath="accountContacts.salesRep.representative" label=i18n.accountsApp.wizard.steps.accountContacts.salesRep.title}}
 		{{> horizontalFieldPartial fieldPath="accountContacts.salesRep.contractEndDate" i18nSectionName="accountContacts.salesRep" i18nFieldName="contractEndDate"}}
 	{{/if}}
-		{{#> horizontalFieldPartial label=i18n.accountsApp.wizard.steps.accountContacts.technicalContact.title hasContent=true}}
+		{{#> horizontalFieldPartial label=i18n.accountsApp.wizard.steps.accountContacts.technicalContact.title hasMultipleFields=true hasContent=true}}
 			<div class="flex-row-container">
 				{{> verticalFieldPartial fieldPath="accountContacts.technicalContact.fullName" i18nSectionName="review.general" i18nFieldName="fullName" hasContent=false}}
 				{{> verticalFieldPartial fieldPath="accountContacts.technicalContact.email" i18nSectionName="general" i18nFieldName="email" hasContent=false}}
 				{{> verticalFieldPartial fieldPath="accountContacts.technicalContact.phoneNumber.userFormat" i18nSectionName="general" i18nFieldName="phoneNumber" hasContent=false}}
 			</div>
 		{{/horizontalFieldPartial}}
-		{{#> horizontalFieldPartial label=i18n.accountsApp.wizard.steps.accountContacts.billingContact.title hasContent=true}}
+		{{#> horizontalFieldPartial label=i18n.accountsApp.wizard.steps.accountContacts.billingContact.title hasMultipleFields=true hasContent=true}}
 			<div class="flex-row-container">
 				{{> verticalFieldPartial fieldPath="accountContacts.billingContact.fullName" i18nSectionName="review.general" i18nFieldName="fullName" hasContent=false}}
 				{{> verticalFieldPartial fieldPath="accountContacts.billingContact.email" i18nSectionName="general" i18nFieldName="email" hasContent=false}}

--- a/submodules/wizard/views/step-review.html
+++ b/submodules/wizard/views/step-review.html
@@ -265,17 +265,15 @@
 					{{tryI18n i18n.accountsApp.wizard.steps.review.appRestrictions.accessLevel.types appRestrictions.accessLevel}}
 				</div>
 			</div>
-			<div class="flex-row-container">
+			<div class="app-list flex-row-container">
 	{{#compare appRestrictions.accessLevel "!==" "full"}}
 		{{#each appRestrictions.apps}}
 			{{#ifInArray id ../appRestrictions.allowedAppIds}}
-				<div class="app-list flex-item-4 flex-container">
-					<div class="flex-item-1 flex-row-container app-item">
-						<div class="flex-item app-icon{{#unless icon}} app-icon-empty{{/unless}} {{extraCssClass}}"{{#if icon}} style="background-image:url({{icon}})"{{/if}}>
-						</div>
-						<div class="flex-item app-name">
-							{{label}}
-						</div>
+				<div class="flex-item-4 flex-container app-item">
+					<div class="flex-item app-icon{{#unless icon}} app-icon-empty{{/unless}} {{extraCssClass}}"{{#if icon}} style="background-image:url({{icon}})"{{/if}}>
+					</div>
+					<div class="flex-item app-name">
+						{{label}}
 					</div>
 				</div>
 			{{/ifInArray}}

--- a/submodules/wizard/views/step-review.html
+++ b/submodules/wizard/views/step-review.html
@@ -82,194 +82,206 @@
 	</div>
 
 	<!-- GENERAL SETTINGS -->
-	{{> sectionTitle stepName="generalSettings"}}
-	<div class="section-body">
-		{{> horizontalFieldPartial fieldPath="generalSettings.accountInfo.accountName" i18nSectionName="generalSettings.accountInfo" i18nFieldName="accountName"}}
-		{{> horizontalFieldPartial fieldPath="generalSettings.accountInfo.accountRealm" i18nSectionName="generalSettings.accountInfo" i18nFieldName="accountRealm"}}
-		{{#> horizontalFieldPartial i18nSectionName="generalSettings.accountInfo" i18nFieldName="addressLine1" hasContent=true}}
-			{{generalSettings.accountInfo.addressLine1}}
-			<br/>
-			{{generalSettings.accountInfo.addressLine2}}
-			<br/>
-			{{generalSettings.accountInfo.addressLine3}}
-		{{/horizontalFieldPartial}}
-		{{> horizontalFieldPartial fieldPath="generalSettings.accountInfo.timezone" i18nSectionName="generalSettings.accountInfo" i18nFieldName="timezone"}}
-		{{> horizontalFieldPartial fieldPath="generalSettings.accountInfo.language" i18nSectionName="generalSettings.accountInfo" i18nFieldName="language"}}
-		{{#> horizontalFieldPartial label=(replaceVar i18n.accountsApp.wizard.steps.review.generalSettings.formats.accountAdminsCount generalSettings.accountAdmins.length) hasMultipleFields=true hasContent=true}}
-			{{#each generalSettings.accountAdmins}}
-				<div class="flex-row-container">
-					{{> verticalFieldPartial fieldPath="fullName" i18nSectionName="review.general" i18nFieldName="fullName"}}
-					{{> verticalFieldPartial fieldPath="email" i18nSectionName="general" i18nFieldName="email"}}
-					{{#> verticalFieldPartial fieldPath="password" i18nSectionName="generalSettings.accountAdmins" i18nFieldName="password"  hasContent=true}}
-						<div class="password-field">
-							<div class="password-value password-hidden">
-								<span class="password-text">
-									{{value}}
-								</span>
-								<span class="password-mask">
-									{{@root.i18n.accountsApp.wizard.steps.review.general.labels.passwordMask}}
-								</span>
+	<div class="section">
+		{{> sectionTitle stepName="generalSettings"}}
+		<div class="section-body">
+			{{> horizontalFieldPartial fieldPath="generalSettings.accountInfo.accountName" i18nSectionName="generalSettings.accountInfo" i18nFieldName="accountName"}}
+			{{> horizontalFieldPartial fieldPath="generalSettings.accountInfo.accountRealm" i18nSectionName="generalSettings.accountInfo" i18nFieldName="accountRealm"}}
+			{{#> horizontalFieldPartial i18nSectionName="generalSettings.accountInfo" i18nFieldName="addressLine1" hasContent=true}}
+				{{generalSettings.accountInfo.addressLine1}}
+				<br/>
+				{{generalSettings.accountInfo.addressLine2}}
+				<br/>
+				{{generalSettings.accountInfo.addressLine3}}
+			{{/horizontalFieldPartial}}
+			{{> horizontalFieldPartial fieldPath="generalSettings.accountInfo.timezone" i18nSectionName="generalSettings.accountInfo" i18nFieldName="timezone"}}
+			{{> horizontalFieldPartial fieldPath="generalSettings.accountInfo.language" i18nSectionName="generalSettings.accountInfo" i18nFieldName="language"}}
+			{{#> horizontalFieldPartial label=(replaceVar i18n.accountsApp.wizard.steps.review.generalSettings.formats.accountAdminsCount generalSettings.accountAdmins.length) hasMultipleFields=true hasContent=true}}
+				{{#each generalSettings.accountAdmins}}
+					<div class="flex-row-container">
+						{{> verticalFieldPartial fieldPath="fullName" i18nSectionName="review.general" i18nFieldName="fullName"}}
+						{{> verticalFieldPartial fieldPath="email" i18nSectionName="general" i18nFieldName="email"}}
+						{{#> verticalFieldPartial fieldPath="password" i18nSectionName="generalSettings.accountAdmins" i18nFieldName="password"  hasContent=true}}
+							<div class="password-field">
+								<div class="password-value password-hidden">
+									<span class="password-text">
+										{{value}}
+									</span>
+									<span class="password-mask">
+										{{@root.i18n.accountsApp.wizard.steps.review.general.labels.passwordMask}}
+									</span>
+								</div>
+								<label class="password-toggle-label">
+									<input type="checkbox" class="password-toggle" data-index="{{@index}}" />
+									<span class="password-show">
+										{{@root.i18n.accountsApp.wizard.steps.review.general.labels.show}}
+									</span>
+									<span class="password-hide">
+										{{@root.i18n.accountsApp.wizard.steps.review.general.labels.hide}}
+									</span>
+								</label>
 							</div>
-							<label class="password-toggle-label">
-								<input type="checkbox" class="password-toggle" data-index="{{@index}}" />
-								<span class="password-show">
-									{{@root.i18n.accountsApp.wizard.steps.review.general.labels.show}}
-								</span>
-								<span class="password-hide">
-									{{@root.i18n.accountsApp.wizard.steps.review.general.labels.hide}}
-								</span>
-							</label>
-						</div>
-					{{/verticalFieldPartial}}
-					{{#> verticalFieldPartial fieldPath="sendMail" i18nSectionName="review.generalSettings" i18nFieldName="sendMail" hasContent=true}}
-						{{> booleanLabel mode="YesNo"}}
-					{{/verticalFieldPartial}}
-				</div>
-			{{/each}}
-		{{/horizontalFieldPartial}}
+						{{/verticalFieldPartial}}
+						{{#> verticalFieldPartial fieldPath="sendMail" i18nSectionName="review.generalSettings" i18nFieldName="sendMail" hasContent=true}}
+							{{> booleanLabel mode="YesNo"}}
+						{{/verticalFieldPartial}}
+					</div>
+				{{/each}}
+			{{/horizontalFieldPartial}}
+		</div>
 	</div>
 
 	<!-- ACCOUNT CONTACTS -->
-	{{> sectionTitle stepName="accountContacts"}}
-	<div class="section-body">
-	{{#if accountContacts.salesRep}}
-		{{> horizontalFieldPartial fieldPath="accountContacts.salesRep.representative" label=i18n.accountsApp.wizard.steps.accountContacts.salesRep.title}}
-		{{> horizontalFieldPartial fieldPath="accountContacts.salesRep.contractEndDate" i18nSectionName="accountContacts.salesRep" i18nFieldName="contractEndDate"}}
-	{{/if}}
-		{{#> horizontalFieldPartial label=i18n.accountsApp.wizard.steps.accountContacts.technicalContact.title hasMultipleFields=true hasContent=true}}
-			<div class="flex-row-container">
-				{{> verticalFieldPartial fieldPath="accountContacts.technicalContact.fullName" i18nSectionName="review.general" i18nFieldName="fullName" hasContent=false}}
-				{{> verticalFieldPartial fieldPath="accountContacts.technicalContact.email" i18nSectionName="general" i18nFieldName="email" hasContent=false}}
-				{{> verticalFieldPartial fieldPath="accountContacts.technicalContact.phoneNumber.userFormat" i18nSectionName="general" i18nFieldName="phoneNumber" hasContent=false}}
-			</div>
-		{{/horizontalFieldPartial}}
-		{{#> horizontalFieldPartial label=i18n.accountsApp.wizard.steps.accountContacts.billingContact.title hasMultipleFields=true hasContent=true}}
-			<div class="flex-row-container">
-				{{> verticalFieldPartial fieldPath="accountContacts.billingContact.fullName" i18nSectionName="review.general" i18nFieldName="fullName" hasContent=false}}
-				{{> verticalFieldPartial fieldPath="accountContacts.billingContact.email" i18nSectionName="general" i18nFieldName="email" hasContent=false}}
-				{{> verticalFieldPartial fieldPath="accountContacts.billingContact.phoneNumber.userFormat" i18nSectionName="general" i18nFieldName="phoneNumber" hasContent=false}}
-			</div>
-		{{/horizontalFieldPartial}}
+	<div class="section">
+		{{> sectionTitle stepName="accountContacts"}}
+		<div class="section-body">
+		{{#if accountContacts.salesRep}}
+			{{> horizontalFieldPartial fieldPath="accountContacts.salesRep.representative" label=i18n.accountsApp.wizard.steps.accountContacts.salesRep.title}}
+			{{> horizontalFieldPartial fieldPath="accountContacts.salesRep.contractEndDate" i18nSectionName="accountContacts.salesRep" i18nFieldName="contractEndDate"}}
+		{{/if}}
+			{{#> horizontalFieldPartial label=i18n.accountsApp.wizard.steps.accountContacts.technicalContact.title hasMultipleFields=true hasContent=true}}
+				<div class="flex-row-container">
+					{{> verticalFieldPartial fieldPath="accountContacts.technicalContact.fullName" i18nSectionName="review.general" i18nFieldName="fullName" hasContent=false}}
+					{{> verticalFieldPartial fieldPath="accountContacts.technicalContact.email" i18nSectionName="general" i18nFieldName="email" hasContent=false}}
+					{{> verticalFieldPartial fieldPath="accountContacts.technicalContact.phoneNumber.userFormat" i18nSectionName="general" i18nFieldName="phoneNumber" hasContent=false}}
+				</div>
+			{{/horizontalFieldPartial}}
+			{{#> horizontalFieldPartial label=i18n.accountsApp.wizard.steps.accountContacts.billingContact.title hasMultipleFields=true hasContent=true}}
+				<div class="flex-row-container">
+					{{> verticalFieldPartial fieldPath="accountContacts.billingContact.fullName" i18nSectionName="review.general" i18nFieldName="fullName" hasContent=false}}
+					{{> verticalFieldPartial fieldPath="accountContacts.billingContact.email" i18nSectionName="general" i18nFieldName="email" hasContent=false}}
+					{{> verticalFieldPartial fieldPath="accountContacts.billingContact.phoneNumber.userFormat" i18nSectionName="general" i18nFieldName="phoneNumber" hasContent=false}}
+				</div>
+			{{/horizontalFieldPartial}}
+		</div>
 	</div>
 
 	<!-- SERVICE PLAN -->
 {{#if servicePlan}}
-	{{> sectionTitle stepName="servicePlan"}}
-	<div class="section-body">
-	{{#if servicePlan.selectedPlans}}
-		{{> horizontalFieldPartial fieldPath="servicePlan.selectedPlans" i18nSectionName="review.servicePlan" i18nFieldName="selectedServicePlans"}}
-		<div class="flex-row-container print-block">
-			<div id="service_plan_aggregate" class="flex-item-4-3">
+	<div class="section">
+		{{> sectionTitle stepName="servicePlan"}}
+		<div class="section-body">
+		{{#if servicePlan.selectedPlans}}
+			{{> horizontalFieldPartial fieldPath="servicePlan.selectedPlans" i18nSectionName="review.servicePlan" i18nFieldName="selectedServicePlans"}}
+			<div class="flex-row-container print-block">
+				<div id="service_plan_aggregate" class="flex-item-4-3">
+				</div>
 			</div>
-		</div>
-	{{else}}
-		<div class="flex-row-container">
-			<div class="flex-item-1 field-label-horizontal">
-				{{i18n.accountsApp.wizard.steps.review.servicePlan.labels.noServicePlan}}
+		{{else}}
+			<div class="flex-row-container">
+				<div class="flex-item-1 field-label-horizontal">
+					{{i18n.accountsApp.wizard.steps.review.servicePlan.labels.noServicePlan}}
+				</div>
 			</div>
+		{{/if}}
 		</div>
-	{{/if}}
 	</div>
 {{/if}}
 
 	<!-- USAGE + CALL RESTRICTIONS -->
-	{{> sectionTitle stepName="usageAndCallRestrictions"}}
-	<div class="section-body">
-		<div class="flex-row-container">
-			<div class="flex-item field-group-column">
-				<div class="flex-row-container">
-					<div class="flex-item-1 column-title">
-						{{i18n.accountsApp.wizard.steps.usageAndCallRestrictions.trunkLimits.title}}
+	<div class="section print-nobreak">
+		{{> sectionTitle stepName="usageAndCallRestrictions"}}
+		<div class="section-body">
+			<div class="flex-row-container">
+				<div class="flex-item field-group-column">
+					<div class="flex-row-container">
+						<div class="flex-item-1 column-title">
+							{{i18n.accountsApp.wizard.steps.usageAndCallRestrictions.trunkLimits.title}}
+						</div>
 					</div>
+					{{> horizontalFieldPartial fieldPath="usageAndCallRestrictions.trunkLimits.inbound" i18nSectionName="usageAndCallRestrictions.trunkLimits" i18nFieldName="inbound"}}
+					{{> horizontalFieldPartial fieldPath="usageAndCallRestrictions.trunkLimits.outbound" i18nSectionName="usageAndCallRestrictions.trunkLimits" i18nFieldName="outbound"}}
+					{{> horizontalFieldPartial fieldPath="usageAndCallRestrictions.trunkLimits.twoway" i18nSectionName="usageAndCallRestrictions.trunkLimits" i18nFieldName="twoway"}}
+					{{#> horizontalFieldPartial fieldPath="usageAndCallRestrictions.allowPerMinuteCalls" i18nSectionName="usageAndCallRestrictions.trunkLimits" i18nFieldName="allowPerMinuteCalls" hasContent=true}}
+						{{> booleanLabel mode="Status"}}
+					{{/horizontalFieldPartial}}
 				</div>
-				{{> horizontalFieldPartial fieldPath="usageAndCallRestrictions.trunkLimits.inbound" i18nSectionName="usageAndCallRestrictions.trunkLimits" i18nFieldName="inbound"}}
-				{{> horizontalFieldPartial fieldPath="usageAndCallRestrictions.trunkLimits.outbound" i18nSectionName="usageAndCallRestrictions.trunkLimits" i18nFieldName="outbound"}}
-				{{> horizontalFieldPartial fieldPath="usageAndCallRestrictions.trunkLimits.twoway" i18nSectionName="usageAndCallRestrictions.trunkLimits" i18nFieldName="twoway"}}
-				{{#> horizontalFieldPartial fieldPath="usageAndCallRestrictions.allowPerMinuteCalls" i18nSectionName="usageAndCallRestrictions.trunkLimits" i18nFieldName="allowPerMinuteCalls" hasContent=true}}
-					{{> booleanLabel mode="Status"}}
-				{{/horizontalFieldPartial}}
-			</div>
-			<div class="flex-item field-group-column">
-				<div class="flex-row-container">
-					<div class="flex-item-1 column-title">
-						{{i18n.accountsApp.wizard.steps.usageAndCallRestrictions.callRestrictions.title}}
+				<div class="flex-item field-group-column">
+					<div class="flex-row-container">
+						<div class="flex-item-1 column-title">
+							{{i18n.accountsApp.wizard.steps.usageAndCallRestrictions.callRestrictions.title}}
+						</div>
 					</div>
+				{{#each usageAndCallRestrictions.callRestrictionTypes}}
+					<div class="flex-row-container">
+						<div class="flex-item field-label-horizontal">
+							{{label}}
+						</div>
+						<div class="flex-item field-value-horizontal">
+							{{> booleanLabel value=(lookup @root.usageAndCallRestrictions.callRestrictions type) mode="Status"}}
+						</div>
+					</div>
+				{{/each}}
 				</div>
-			{{#each usageAndCallRestrictions.callRestrictionTypes}}
-				<div class="flex-row-container">
-					<div class="flex-item field-label-horizontal">
-						{{label}}
-					</div>
-					<div class="flex-item field-value-horizontal">
-						{{> booleanLabel value=(lookup @root.usageAndCallRestrictions.callRestrictions type) mode="Status"}}
-					</div>
-				</div>
-			{{/each}}
 			</div>
 		</div>
 	</div>
 
 	<!-- CREDIT BALANCE + FEATURES -->
-	{{> sectionTitle stepName="creditBalanceAndFeatures"}}
-	<div class="section-body">
-		<div class="flex-row-container">
-			<div class="flex-item field-group-column">
-				<div class="flex-row-container">
-					<div class="flex-item-1 column-title">
-						{{i18n.accountsApp.wizard.steps.creditBalanceAndFeatures.accountCredit.title}}
+	<div class="section print-nobreak">
+		{{> sectionTitle stepName="creditBalanceAndFeatures"}}
+		<div class="section-body">
+			<div class="flex-row-container">
+				<div class="flex-item field-group-column">
+					<div class="flex-row-container">
+						<div class="flex-item-1 column-title">
+							{{i18n.accountsApp.wizard.steps.creditBalanceAndFeatures.accountCredit.title}}
+						</div>
 					</div>
+					{{#> horizontalFieldPartial fieldPath="creditBalanceAndFeatures.accountCredit.initialBalance" i18nSectionName="creditBalanceAndFeatures.accountCredit" i18nFieldName="initialBalance" hasContent=true}}
+						{{formatPrice value 2}}
+					{{/horizontalFieldPartial}}
 				</div>
-				{{#> horizontalFieldPartial fieldPath="creditBalanceAndFeatures.accountCredit.initialBalance" i18nSectionName="creditBalanceAndFeatures.accountCredit" i18nFieldName="initialBalance" hasContent=true}}
-					{{formatPrice value 2}}
-				{{/horizontalFieldPartial}}
-			</div>
-			<div class="flex-item field-group-column">
-				<div class="flex-row-container">
-					<div class="flex-item-1 column-title">
-						{{i18n.accountsApp.wizard.steps.creditBalanceAndFeatures.controlCenterAccess.title}}
+				<div class="flex-item field-group-column">
+					<div class="flex-row-container">
+						<div class="flex-item-1 column-title">
+							{{i18n.accountsApp.wizard.steps.creditBalanceAndFeatures.controlCenterAccess.title}}
+						</div>
 					</div>
+				{{#each creditBalanceAndFeatures.controlCenterAccess.featureList}}
+					<div class="flex-row-container">
+						<div class="flex-item field-label-horizontal">
+							{{telicon icon class="feature-icon iconography-medium"}}
+							<span class="iconography-text-right">
+								{{tryI18n @root.i18n.accountsApp.wizard.steps.creditBalanceAndFeatures.controlCenterAccess.features.labels name}}
+							</span>
+						</div>
+						<div class="flex-item field-value-horizontal">
+							{{> booleanLabel value=(lookup @root.creditBalanceAndFeatures.controlCenterAccess.features name) mode="Status"}}
+						</div>
+					</div>
+				{{/each}}
 				</div>
-			{{#each creditBalanceAndFeatures.controlCenterAccess.featureList}}
-				<div class="flex-row-container">
-					<div class="flex-item field-label-horizontal">
-						{{telicon icon class="feature-icon iconography-medium"}}
-						<span class="iconography-text-right">
-							{{tryI18n @root.i18n.accountsApp.wizard.steps.creditBalanceAndFeatures.controlCenterAccess.features.labels name}}
-						</span>
-					</div>
-					<div class="flex-item field-value-horizontal">
-						{{> booleanLabel value=(lookup @root.creditBalanceAndFeatures.controlCenterAccess.features name) mode="Status"}}
-					</div>
-				</div>
-			{{/each}}
 			</div>
 		</div>
 	</div>
 
 	<!-- APP RESTRICTIONS -->
-	{{> sectionTitle stepName="appRestrictions"}}
-	<div class="section-body">
-		<div class="flex-row-container">
-			<div class="flex-item-1">
-				{{tryI18n i18n.accountsApp.wizard.steps.review.appRestrictions.accessLevel.types appRestrictions.accessLevel}}
-			</div>
-		</div>
-		<div class="flex-row-container">
-{{#compare appRestrictions.accessLevel "!==" "full"}}
-	{{#each appRestrictions.apps}}
-		{{#ifInArray id ../appRestrictions.allowedAppIds}}
-			<div class="app-list flex-item-4 flex-container">
-				<div class="flex-item-1 flex-row-container app-item">
-					<div class="flex-item app-icon{{#unless icon}} app-icon-empty{{/unless}} {{extraCssClass}}"{{#if icon}} style="background-image:url({{icon}})"{{/if}}>
-					</div>
-					<div class="flex-item app-name">
-						{{label}}
-					</div>
+	<div class="section">
+		{{> sectionTitle stepName="appRestrictions"}}
+		<div class="section-body">
+			<div class="flex-row-container">
+				<div class="flex-item-1">
+					{{tryI18n i18n.accountsApp.wizard.steps.review.appRestrictions.accessLevel.types appRestrictions.accessLevel}}
 				</div>
 			</div>
-		{{/ifInArray}}
-	{{/each}}
-{{/compare}}
+			<div class="flex-row-container">
+	{{#compare appRestrictions.accessLevel "!==" "full"}}
+		{{#each appRestrictions.apps}}
+			{{#ifInArray id ../appRestrictions.allowedAppIds}}
+				<div class="app-list flex-item-4 flex-container">
+					<div class="flex-item-1 flex-row-container app-item">
+						<div class="flex-item app-icon{{#unless icon}} app-icon-empty{{/unless}} {{extraCssClass}}"{{#if icon}} style="background-image:url({{icon}})"{{/if}}>
+						</div>
+						<div class="flex-item app-name">
+							{{label}}
+						</div>
+					</div>
+				</div>
+			{{/ifInArray}}
+		{{/each}}
+	{{/compare}}
+			</div>
 		</div>
 	</div>
 </div>

--- a/submodules/wizard/views/step-review.html
+++ b/submodules/wizard/views/step-review.html
@@ -157,17 +157,11 @@
 	{{> sectionTitle stepName="servicePlan"}}
 	<div class="section-body">
 	{{#if servicePlan.selectedPlans}}
-		{{#> horizontalFieldPartial fieldPath="servicePlan.selectedPlans" i18nSectionName="review.servicePlan" i18nFieldName="selectedServicePlans" hasContent=true}}
-			<div class="flex-row-container">
-				<div class="flex-item-1">
-					{{value}}
-				</div>
+		{{> horizontalFieldPartial fieldPath="servicePlan.selectedPlans" i18nSectionName="review.servicePlan" i18nFieldName="selectedServicePlans"}}
+		<div class="flex-row-container print-block">
+			<div id="service_plan_aggregate" class="flex-item-4-3">
 			</div>
-			<div class="flex-row-container">
-				<div id="service_plan_aggregate" class="flex-item-1">
-				</div>
-			</div>
-		{{/horizontalFieldPartial}}
+		</div>
 	{{else}}
 		<div class="flex-row-container">
 			<div class="flex-item-1 field-label-horizontal">

--- a/submodules/wizard/views/step-review.html
+++ b/submodules/wizard/views/step-review.html
@@ -18,7 +18,7 @@
 		</div>
 		<div class="flex-item-4-3 field-value-horizontal{{#if hasMultipleFields}} field-value-multiple{{/if}}">
 		{{#if hasContent}}	{{!-- Necessary to know if there is a @partial-block to render, and to avoid endless recursion --}}
-			{{> @partial-block value=(lookupPath this (coalesce fieldPath i18nFieldName))}}
+			{{> @partial-block label=null value=(lookupPath this (coalesce fieldPath i18nFieldName))}}
 		{{else}}
 			{{lookupPath this (coalesce fieldPath i18nFieldName)}}
 		{{/if}}

--- a/submodules/wizard/views/step-review.html
+++ b/submodules/wizard/views/step-review.html
@@ -76,10 +76,10 @@
 		<div class="step-title flex-fit">
 			{{i18n.accountsApp.wizard.steps.review.title}}
 		</div>
-		<button class="step-action-button flex-initial">
+		<button id="step_download" class="step-action-button flex-initial">
 			{{telicon "download-cloud"}}
 		</button>
-		<button class="step-action-button flex-initial">
+		<button id="step_print" class="step-action-button flex-initial">
 			{{telicon "device-fax"}}
 		</button>
 	</div>

--- a/submodules/wizard/views/step-review.html
+++ b/submodules/wizard/views/step-review.html
@@ -76,10 +76,10 @@
 		<div class="step-title flex-fit">
 			{{i18n.accountsApp.wizard.steps.review.title}}
 		</div>
-		<button id="step_download" class="step-action-button flex-initial">
+		<button class="step-action-button flex-initial">
 			{{telicon "download-cloud"}}
 		</button>
-		<button id="step_print" class="step-action-button flex-initial">
+		<button class="step-action-button flex-initial">
 			{{telicon "device-fax"}}
 		</button>
 	</div>

--- a/submodules/wizard/views/step-review.html
+++ b/submodules/wizard/views/step-review.html
@@ -72,8 +72,16 @@
 {{/inline}}
 
 <div id="step_review" class="wizard-step">
-	<div class="step-title">
-		{{i18n.accountsApp.wizard.steps.review.title}}
+	<div class="flex-container">
+		<div class="step-title flex-fit">
+			{{i18n.accountsApp.wizard.steps.review.title}}
+		</div>
+		<button class="step-action-button flex-initial">
+			{{telicon "download-cloud"}}
+		</button>
+		<button class="step-action-button flex-initial">
+			{{telicon "device-fax"}}
+		</button>
 	</div>
 
 	<!-- GENERAL SETTINGS -->

--- a/submodules/wizard/views/step-review.html
+++ b/submodules/wizard/views/step-review.html
@@ -76,7 +76,7 @@
 		<div class="step-title flex-fit">
 			{{i18n.accountsApp.wizard.steps.review.title}}
 		</div>
-		<button id="step_print" class="step-action-button flex-initial">
+		<button id="step_print" class="monster-button step-action flex-initial">
 			{{telicon "device-fax"}}
 		</button>
 	</div>

--- a/submodules/wizard/views/step-review.html
+++ b/submodules/wizard/views/step-review.html
@@ -60,7 +60,7 @@
 	{{else}}
 		<div class="text-danger">
 			{{telicon "x--circle" class="iconography-medium"}}
-			<span>
+			<span class="iconography-text">
 			{{#compare mode "===" "Status"}}
 				{{tryI18n @root.i18n.accountsApp.wizard.steps.review.general.labels "disabled"}}
 			{{else}}
@@ -169,6 +169,7 @@
 			</div>
 		</div>
 	{{/if}}
+	</div>
 {{/if}}
 
 	<!-- USAGE + CALL RESTRICTIONS -->

--- a/submodules/wizard/wizard.js
+++ b/submodules/wizard/wizard.js
@@ -1424,6 +1424,14 @@ define(function(require) {
 								.find('.password-value')
 									.toggleClass('password-hidden');
 					});
+
+			$template
+				.find('#step_print')
+					.on('click', function(e) {
+						e.preventDefault();
+
+						window.print();
+					});
 		},
 
 		/* SUBMIT */

--- a/submodules/wizard/wizard.js
+++ b/submodules/wizard/wizard.js
@@ -1,12 +1,9 @@
 define(function(require) {
 	var $ = require('jquery'),
 		_ = require('lodash'),
-		pdfMake = require('pdfmake'),
 		moment = require('moment'),
 		monster = require('monster'),
 		timezone = require('monster-timezone');
-
-	require('vfs_fonts');
 
 	var wizard = {
 
@@ -86,27 +83,6 @@ define(function(require) {
 						}
 					]
 				},
-				pdfStaticValues: {
-					styles: {
-						header: {
-							fontSize: 16,
-							bold: true
-						},
-						subHeader: {
-							fontSize: 14,
-							bold: true,
-							decoration: 'underline'
-						},
-						textNormal: {
-							fontSize: 9
-						},
-						textLabel: {
-						},
-						textValue: {
-							bold: true
-						}
-					}
-				},
 				stepNames: [
 					'generalSettings',
 					'accountContacts',
@@ -177,9 +153,6 @@ define(function(require) {
 				},
 				stepNames = self.appFlags.wizard.stepNames;
 
-			// TODO: Remove this. Is for test purposes only.
-			_.merge(defaultData, {"parentAccountId":"f795086a93dbffec4ac250167961b8a9","creditBalanceAndFeatures":{"controlCenterAccess":{"features":{"user":true,"account":false,"billing":true,"balance":true,"credit":true,"minutes":false,"service_plan":true,"transactions":true,"error_tracker":false}},"accountCredit":{"initialBalance":"500.00"}},"generalSettings":{"accountInfo":{"accountName":"New VoIP Company Account","accountRealm":"newvoip.test.com","addressLine1":"140 Geary St.","addressLine2":"3rd Floor","city":"San Francisco","state":"CA","zip":"94108","country":"USA","timezone":"America/New_York","language":"en-US"},"accountAdmins":[{"firstName":"John","lastName":"Smith","email":"jsmith@email.nonexistent","password":"xhi892sdh82","sendMail":true},{"firstName":"Jane","lastName":"Doe","email":"jane@email.nonexistent","password":"29jkhas92un","sendMail":false}]},"accountContacts":{"technicalContact":{"fullName":"John Smith","email":"jsmith@email.nonexistent","phoneNumber":{"isValid":true,"originalNumber":"4158862600","userFormat":"+1 415 886 2600","e164Number":"+14158862600","nationalFormat":"(415) 886-2600","internationalFormat":"+1 415 886 2600","country":{"code":"US","name":"United States"},"userFormatType":"international"}},"billingContact":{"fullName":"Mary Doe","email":"mary@email.nonexistent","phoneNumber":{"isValid":true,"originalNumber":"+14158862600","userFormat":"+1 415 886 2600","e164Number":"+14158862600","nationalFormat":"(415) 886-2600","internationalFormat":"+1 415 886 2600","country":{"code":"US","name":"United States"},"userFormatType":"international"}}},"servicePlan":{"selectedPlanIds":["35f6a034f50cfd9994ede2e3432e1e0a"]},"usageAndCallRestrictions":{"trunkLimits":{"inbound":"50","outbound":"25","twoway":"35"},"allowPerMinuteCalls":true,"callRestrictions":{"caribbean":true,"emergency":true,"did_us":true,"international":false,"toll_us":true,"tollfree_us":true,"unknown":true}},"appRestrictions":{"accessLevel":"restricted","allowedAppIds":["15b46a578ed892dae676c32696736668","b5db02f38dca8c053e1f8d7018aef086","8ec45dc2f7c5ec54aadd688e05184187","cd810ac95c1a68ba0c010773c4698b5d"]}});
-
 			// Clean store, in case it was not empty, to avoid using old data
 			self.wizardSetStore({});
 
@@ -221,8 +194,7 @@ define(function(require) {
 					thisArg: self,
 					data: defaultData,
 					container: $container,
-					// TODO: Remove filter for stepNames. For testing purposes only.
-					steps: _.map(['review'], function(stepName) {
+					steps: _.map(stepNames, function(stepName) {
 						var pascalCasedStepName = _.upperFirst(stepName);
 
 						return {
@@ -1274,20 +1246,13 @@ define(function(require) {
 			var self = this,
 				data = args.data,
 				$container = args.container,
-				formattedAccountData = self.wizardReviewFormatData(data),
+				dataTemplate = self.wizardReviewFormatData(data),
 				$template = $(self.getTemplate({
 					name: 'step-review',
-					data: formattedAccountData,
+					data: dataTemplate,
 					submodule: 'wizard'
 				})),
-				initTemplate = function(reviewData) {
-					var pdfDocDefinition = self.wizardPdfGenerateDocDefinition({
-						data: formattedAccountData,
-						images: {
-							brandingLogo: reviewData.logo
-						}
-					});
-
+				initTemplate = function() {
 					monster.ui.tooltips($template);
 
 					// The numbering is dynamically set through jQuery
@@ -1297,58 +1262,33 @@ define(function(require) {
 					});
 
 					self.wizardReviewBindEvents({
-						template: $template,
-						pdfDocDefinition: pdfDocDefinition
+						template: $template
 					});
 
 					return $template;
 				},
-				parallelFunctions = {
-					logo: function(parallelCallback) {
-						monster.waterfall([
-							function(waterfallCallback) {
-								self.wizardRequestWhitelabelLogo({
-									success: function() {
-										waterfallCallback(null, self.apiUrl + 'accounts/' + self.accountId + '/whitelabel/logo?auth_token=' + self.getAuthToken());
-									},
-									error: function() {
-										waterfallCallback(null, 'apps/core/style/static/images/logo.svg');
-									}
-								});
-							},
-							function(src, waterfallCallback) {
-								self.wizardConvertImageToDataUrl(src, function(dataUrl) {
-									waterfallCallback(null, dataUrl);
-								});
-							}
-						], parallelCallback);
-					},
-					servicePlan: function(parallelCallback) {
-						self.serviceItemsListingRender({
-							planIds: data.servicePlan.selectedPlanIds,
-							container: $template.find('#service_plan_aggregate'),
-							showProgressPanel: false,
-							success: function() {
-								parallelCallback(null);
-							},
-							error: function(err) {
-								parallelCallback(null);
-							}
-						});
-					}
+				renderStepArgs = {
+					container: $container,
+					initTemplate: initTemplate
 				};
 
-			console.log('data', JSON.stringify(data));
-
-			if (!_.has(data, 'servicePlan')) {
-				delete parallelFunctions.servicePlan;
+			if (_.has(data, 'servicePlan')) {
+				renderStepArgs.loadData = function(asyncCallback) {
+					self.serviceItemsListingRender({
+						planIds: data.servicePlan.selectedPlanIds,
+						container: $template.find('#service_plan_aggregate'),
+						showProgressPanel: false,
+						success: function() {
+							asyncCallback(null);
+						},
+						error: function(err) {
+							asyncCallback(null);
+						}
+					});
+				};
 			}
 
-			self.wizardRenderStep({
-				container: $container,
-				loadData: _.partial(monster.parallel, parallelFunctions),
-				initTemplate: initTemplate
-			});
+			self.wizardRenderStep(renderStepArgs);
 		},
 
 		/**
@@ -1458,12 +1398,10 @@ define(function(require) {
 		 * Bind Review step events
 		 * @param  {Object} args
 		 * @param  {jQuery} args.template  Step template
-		 * @param  {Object} args.pdfDocDefinition  PDF account document definition
 		 */
 		wizardReviewBindEvents: function(args) {
 			var self = this,
-				$template = args.template,
-				pdfDocDefinition = args.pdfDocDefinition;
+				$template = args.template;
 
 			$template
 				.find('.edit-step')
@@ -1485,18 +1423,6 @@ define(function(require) {
 							.closest('.password-field')
 								.find('.password-value')
 									.toggleClass('password-hidden');
-					});
-
-			$template
-				.find('#step_print')
-					.on('click', function() {
-						self.wizardPdfGetOrCreate(pdfDocDefinition).print();
-					});
-
-			$template
-				.find('#step_download')
-					.on('click', function() {
-						self.wizardPdfGetOrCreate(pdfDocDefinition).download();
 					});
 		},
 
@@ -1864,420 +1790,6 @@ define(function(require) {
 			});
 		},
 
-		/* PDF GENERATION */
-
-		/**
-		 * Gets a PDF from store if it exists, or generates a new PDF document based on the
-		 * provided definition
-		 * @param  {Object} pdfDoc
-		 * @param  {String} pdfDoc.id  Document unique ID
-		 * @param  {String} pdfDoc.definition  Document definition
-		 */
-		wizardPdfGetOrCreate: function(pdfDoc) {
-			var self = this,
-				documentId = pdfDoc.id,
-				documentDefinition = pdfDoc.definition,
-				pdfDocumentData = self.wizardGetStore('pdfDocument');
-
-			if (_.get(pdfDocumentData, 'id') === documentId) {
-				return pdfDocumentData;
-			}
-
-			// Document does not exist or is outdated, so create it
-			pdfDocumentData = {
-				id: documentId,
-				document: pdfMake.createPdf(documentDefinition)
-			};
-
-			console.log('PDF doc', pdfDocumentData);
-
-			self.wizardSetStore('pdfDocument', pdfDocumentData);
-
-			return pdfDocumentData.document;
-		},
-
-		/**
-		 * Generate the review's PDF document definition
-		 * @param  {Object} args
-		 * @param  {Object} args.data  Wizard data, formatted for the review step
-		 * @param  {Object} args.images  Images to be rendered inside the PDF document
-		 */
-		wizardPdfGenerateDocDefinition: function(args) {
-			var self = this,
-				data = args.data,
-				images = args.images;
-
-			return {
-				id: monster.util.guid(),
-				definition: {
-					content: self.wizardPdfBuildContent(data),
-					header: self.wizardPdfBuildHeader.bind(self),
-					images: images,
-					//info: self.pdfInfo(),
-					pageMargins: [20, 100, 20, 20],
-					pageSize: 'letter',
-					styles: self.appFlags.wizard.pdfStaticValues.styles
-				}
-			};
-		},
-
-		wizardPdfBuildHeader: function(currentPage, pageCount) {
-			var self = this,
-				i18n = self.i18n.active().accountsApp.wizard.document;
-
-			return {
-				margin: [20, 20, 20, 0],
-				columns: [
-					{
-						layout: 'noBorders',
-						width: '*',
-						table: {
-							body: [
-								[
-									{
-										fillColor: 'black',
-										image: 'brandingLogo',
-										width: 132
-									}
-								]
-							]
-						}
-					},
-					{
-						layout: 'noBorders',
-						width: 'auto',
-						table: {
-							widths: ['*', 'auto'],
-							body: [
-								[{
-									alignment: 'right',
-									fontSize: 7,
-									text: i18n.header.page
-								}, {
-									fontSize: 7,
-									text: self.getTemplate({
-										name: '!' + i18n.header.pageOf,
-										data: {
-											current: currentPage.toString(),
-											total: pageCount.toString()
-										}
-									})
-								}],
-								[{
-									alignment: 'right',
-									fontSize: 7,
-									text: i18n.header.date
-								}, {
-									fontSize: 7,
-									text: monster.util.toFriendlyDate(moment().toDate(), 'date')
-								}]
-							]
-						}
-					}
-				]
-			};
-		},
-
-		/**
-		 * Generate PDF content
-		 * @param  {Object} wizardReviewData  Wizard data, formatted for the review step
-		 */
-		wizardPdfBuildContent: function(wizardReviewData) {
-			var self = this,
-				i18n = self.i18n.active();
-
-			return [
-				{
-					text: i18n.accountsApp.wizard.steps.review.title,
-					style: 'header'
-				},
-				{
-					table: {
-						headerRows: 0,
-						widths: ['100%'],
-						body: self.wizardPdfBuildAllSections(wizardReviewData)
-					},
-					layout: {
-						hLineWidth: function(i) {
-							return (i % 2 === 0) ? 0 : 1;
-						},
-						vLineWidth: function() {
-							return 0;
-						}
-					}
-				}
-			];
-		},
-
-		/**
-		 * Generate main sections for PDF content
-		 * @param  {Object} wizardReviewData  Wizard data, formatted for the review step
-		 */
-		wizardPdfBuildAllSections: function(wizardReviewData) {
-			var self = this,
-				i18n = self.i18n.active();
-
-			return _
-				.chain(wizardReviewData)
-				.pick(self.appFlags.wizard.stepNames)	// Pick only data that belong to the wizard steps
-				.map(function(sectionData, sectionKey) {
-					return {
-						key: sectionKey,
-						data: sectionData
-					};
-				})
-				.flatMap(function(sectionInfo, index) {
-					var sectionKey = sectionInfo.key,
-						sectionData = sectionInfo.data,
-						sectionTitle = _.get(i18n.accountsApp.wizard.steps, [ sectionKey, 'label' ], _.startCase(sectionKey)),
-						buildFunctionName = 'wizardPdfBuild' + _.upperFirst(sectionKey);
-
-					return [
-						[
-							self.getTemplate({
-								name: '!' + i18n.accountsApp.wizard.document.sections.title,
-								data: {
-									correlative: index + 1,
-									title: sectionTitle
-								}
-							})
-						],
-						[
-							self[buildFunctionName]({
-								sectionKey: sectionKey,
-								sectionData: sectionData
-							})
-						]
-					];
-				})
-				.value();
-		},
-
-		/**
-		 * Build the General Settings section for the PDF content
-		 * @param  {Object} args
-		 * @param  {String} args.sectionKey  Section key
-		 * @param  {Object} args.sectionData  Section data
-		 */
-		wizardPdfBuildGeneralSettings: function(args) {
-			var self = this,
-				sectionKey = args.sectionKey,
-				sectionData = args.sectionData;
-
-			console.log('sectionData', sectionData);
-
-			return {
-				table: {
-					headerRows: 0,
-					widths: ['25%', '*'],
-					body: [
-						self.wizardPdfBuildHorizontalDataField({
-							fieldPath: [ sectionKey, 'accountInfo', 'accountName' ],
-							data: sectionData
-						}),
-						self.wizardPdfBuildHorizontalDataField({
-							fieldPath: [ sectionKey, 'accountInfo', 'accountRealm' ],
-							data: sectionData
-						}),
-						self.wizardPdfBuildHorizontalDataField({
-							fieldPath: [ sectionKey, 'accountInfo', 'addressLine1' ],
-							value: _
-								.chain(sectionData.accountInfo)
-								.filter(function(value, key) {
-									return _.startsWith(key, 'addressLine');
-								})
-								.join('\n')
-								.value()
-						}),
-						self.wizardPdfBuildHorizontalDataField({
-							fieldPath: [ sectionKey, 'accountInfo', 'timezone' ],
-							data: sectionData
-						}),
-						self.wizardPdfBuildHorizontalDataField({
-							fieldPath: [ sectionKey, 'accountInfo', 'language' ],
-							data: sectionData
-						}),
-						self.wizardPdfBuildHorizontalDataField({
-							label: self.getTemplate({
-								name: '!' + self.i18n.active().accountsApp.wizard.steps.review.generalSettings.formats.accountAdminsCount,
-								data: {
-									variable: sectionData.accountAdmins.length
-								}
-							}),
-							value: self.wizardPdfBuildDataTable({
-								items: sectionData.accountAdmins,
-								fields: {
-									fullName: 'review.general.labels.fullName',
-									email: 'general.labels.email',
-									password: 'generalSettings.accountAdmins.labels.password',
-									sendMail: 'review.generalSettings.labels.sendMail'
-								}
-							})
-						})
-					]
-				},
-				layout: 'noBorders'
-			};
-		},
-
-		/**
-		 * Build the Account Contacts section for the PDF content
-		 * @param  {Object} args
-		 * @param  {String} args.sectionKey  Section key
-		 * @param  {Object} args.sectionData  Section data
-		 */
-		wizardPdfBuildAccountContacts: function(args) {
-			return [];
-		},
-
-		/**
-		 * Build the Service Plan section for the PDF content
-		 * @param  {Object} args
-		 * @param  {String} args.sectionKey  Section key
-		 * @param  {Object} args.sectionData  Section data
-		 */
-		wizardPdfBuildServicePlan: function(args) {
-			return [];
-		},
-
-		/**
-		 * Build the Usage And Call Restrictions section for the PDF content
-		 * @param  {Object} args
-		 * @param  {String} args.sectionKey  Section key
-		 * @param  {Object} args.sectionData  Section data
-		 */
-		wizardPdfBuildUsageAndCallRestrictions: function(args) {
-			return [];
-		},
-
-		/**
-		 * Build the Credit Balance And Features section for the PDF content
-		 * @param  {Object} args
-		 * @param  {String} args.sectionKey  Section key
-		 * @param  {Object} args.sectionData  Section data
-		 */
-		wizardPdfBuildCreditBalanceAndFeatures: function(args) {
-			return [];
-		},
-
-		/**
-		 * Build the App Restrictions section for the PDF content
-		 * @param  {Object} args
-		 * @param  {String} args.sectionKey  Section key
-		 * @param  {Object} args.sectionData  Section data
-		 */
-		wizardPdfBuildAppRestrictions: function(args) {
-			return [];
-		},
-
-		/**
-		 * Builds a data row
-		 * @param  {Object} args
-		 * @param  {String} args.fieldPath  Path to the field that contains the data. Includes the section name.
-		 * @param  {Object} [args.data]  Section data
-		 * @param  {String|Object} [args.value]  Specific value
-		 */
-		wizardPdfBuildHorizontalDataField: function(args) {
-			var self = this,
-				path = args.fieldPath,
-				data = args.data,
-				label = args.label,
-				value = args.value,
-				fieldName,
-				labelsPath,
-				i18n,
-				dataPath;
-
-			if (path) {
-				fieldName = _.last(path);
-				labelsPath = _
-					.chain(path)
-					.take(path.length - 1)	// Exclude field name
-					.concat([ 'labels' ])
-					.value();
-				i18n = _.get(self.i18n.active().accountsApp.wizard.steps, labelsPath, {});
-				dataPath = _.drop(path, 1);	// Remove section name from path
-
-				if (_.isUndefined(label)) {
-					label = monster.util.tryI18n(i18n, fieldName);
-				}
-
-				if (_.isUndefined(value)) {
-					value = _.get(data, dataPath, '');
-				}
-			}
-
-			return [
-				{
-					text: label,
-					style: [ 'textNormal', 'textLabel' ]
-				},
-				_.isString(value)
-					? {
-						text: value,
-						style: [ 'textNormal', 'textValue' ]
-					}
-					: value
-			];
-		},
-
-		/**
-		 * Builds a data table definition, to render a list of items
-		 * @param  {Object} args
-		 * @param  {Object[]} args.items  Data items
-		 * @param  {Object} args.fields  Object whose property names are the paths to each item's
-		 *                               data, and they values are the paths to the i18n label
-		 */
-		wizardPdfBuildDataTable: function(args) {
-			var self = this,
-				items = args.items,
-				fields = args.fields,
-				i18n = self.i18n.active().accountsApp.wizard.steps;
-
-			return {
-				table: {
-					headerRows: 0,
-					widths: ['25%', '25%', '25%', '%25'],	// TODO: Make this kinda dynamic
-					body: _.map(items, function(item) {
-						return _.map(fields, function(fieldI18nPath, fieldValuePath) {
-							var value = _.get(item, fieldValuePath, '');
-
-							if (_.isBoolean(value)) {
-								value = self.wizardPdfBuildBooleanLabel(value);
-							}
-
-							return [
-								_.get(i18n, fieldI18nPath),
-								value
-							];
-						});
-					})
-				},
-				layout: 'noBorders'
-			};
-		},
-
-		/**
-		 * Returns the label representation for a boolean value
-		 * @param  {Object} args
-		 * @param  {('Status'|'YesNo')} args.mode  Mode to build the boolean value
-		 * @param  {Boolean} args.value  Value
-		 */
-		wizardPdfBuildBooleanLabel: function(args) {
-			var self = this,
-				mode = args.mode,
-				value = args.value,
-				i18n = self.i18n.active().accountsApp.wizard.steps.review.general.labels,
-				i18nTrue = (mode === 'Status')
-					? monster.util.tryI18n(i18n, 'enabled')
-					: monster.util.tryI18n(i18n, 'yes'),
-				i18nFalse = (mode === 'Status')
-					? monster.util.tryI18n(i18n, 'disabled')
-					: monster.util.tryI18n(i18n, 'no');
-
-			return value ? i18nTrue : i18nFalse;
-		},
-
 		/* CLOSE WIZARD */
 
 		/**
@@ -2464,32 +1976,6 @@ define(function(require) {
 			});
 		},
 
-		/**
-		 * Retrieves the whitelabel logo, if there's any
-		 * @param  {Object} args
-		 * @param  {Object} [args.data]
-		 * @param  {Function} [args.success]
-		 * @param  {Function} [args.error]
-		 */
-		wizardRequestWhitelabelLogo: function(args) {
-			var self = this;
-
-			self.callApi({
-				resource: 'whitelabel.getLogo',
-				data: _.merge({
-					accountId: self.accountId,
-					dataType: '*',
-					generateError: false
-				}, args.data),
-				success: function(data, status) {
-					_.has(args, 'success') && args.success(data.data);
-				},
-				error: function(parsedError) {
-					_.has(args, 'error') && args.error(parsedError);
-				}
-			});
-		},
-
 		/* UTILITY FUNCTIONS */
 
 		/**
@@ -2515,30 +2001,6 @@ define(function(require) {
 					.appendTo($listContainer)
 					.slideDown(animationDuration);
 			}
-		},
-
-		/**
-		 * Convert image to dataURL
-		 * Function copied from monster-ui-invoices/app.js
-		 * @param  {String}   src  Image URL
-		 * @param  {Function} callback
-		 */
-		wizardConvertImageToDataUrl: function(src, callback) {
-			var img = new Image();
-			img.crossOrigin = 'anonymous';
-			img.src = src;
-			img.onload = function() {
-				var canvas = document.createElement('CANVAS'),
-					ctx = canvas.getContext('2d'),
-					dataURL;
-				canvas.height = this.naturalHeight;
-				canvas.width = this.naturalWidth;
-				ctx.webkitImageSmoothingEnabled = false;
-				ctx.imageSmoothingEnabled = false;
-				ctx.drawImage(this, 0, 0);
-				dataURL = canvas.toDataURL();
-				callback(dataURL);
-			};
 		},
 
 		/**

--- a/submodules/wizard/wizard.scss
+++ b/submodules/wizard/wizard.scss
@@ -4,7 +4,12 @@ $media-size-small: "screen and (max-width : 736px)";
 $media-size-medium: "screen and (max-width : 980px)";
 $color-highlight: #dbdbde;
 
+// Some lengths are specified in em, to be able to resize it for printing by only changing the
+// font size of the step's container
+// Beware that the em size for an element is proportional to its font-size, or its parent font size
+// which means that if the font-size:8px, then a margin:0.5em will be equivalent to 4px
 #navigation_wizard_wrapper .wizard-step {
+	font-size: 1rem;	// Set base font size for container
 	padding: 2rem 1.5rem;
 
 	.iconography-small {
@@ -100,9 +105,9 @@ $color-highlight: #dbdbde;
 	}
 
 	.step-title {
-		padding-bottom: 1.5rem;
-		font-size: 23px;
-		line-height: 1.875rem;
+		padding-bottom: 1.0434em;	// 24px
+		font-size: 1.4375em;		// 23px
+		line-height: 1em;			// 23px
 		color: $woodsmoke;
 	}
 
@@ -116,12 +121,12 @@ $color-highlight: #dbdbde;
 	}
 
 	.section-title {
-		margin-top: 1rem;
-		margin-bottom: 1.5rem;
-		padding-bottom: 0.75rem;
+		margin-top: 1em;		// 16px
+		margin-bottom: 1.5em;	// 24px
+		padding-bottom: 0.75em;	// 12px
 		border-bottom: solid 1px $french-gray2;
-		line-height: 1rem;
-		font-size: 1rem;
+		line-height: 1em;		// 16px
+		font-size: 1em;			// 16px
 		font-weight: 600;
 		color: $woodsmoke;
 
@@ -133,7 +138,7 @@ $color-highlight: #dbdbde;
 			}
 
 			.iconography-medium {
-				margin-top: -0.25rem;
+				margin-top: -0.25em;	// -4px
 			}
 		}
 	}
@@ -619,37 +624,42 @@ $color-highlight: #dbdbde;
 			font-weight: 600;
 
 			.iconography-medium {
-				margin-right: 0.5rem;
+				margin-right: 0.5em;	// 8px
+				width: 1em;				// 16px
+				height: 1em;			// 16px
 			}
 		}
 
 		.field-label-horizontal, .field-value-horizontal {
-			margin-top: -0.25rem;
-			margin-bottom: 0.25rem;
-			padding-bottom: 1rem;
-			line-height: 21px;
+			font-size: 0.875em;			// 14px
+			margin-top: -0.2857em;		// -4px
+			margin-bottom: 0.2857em;	// 4px
+			padding-bottom: 1.1429em;	// 16px
+			line-height: 1.4286em;		// 20px
 		}
 
 		.field-label-horizontal {
 			color: $woodsmoke;
-			letter-spacing: 0px;
+			letter-spacing: 0;
 		}
 
-		.field-value-horizontal .flex-row-container:last-child {
-			margin-bottom: -1.5rem;
-		}
+		.field-value-horizontal {
+			.flex-row-container:last-child {
+				margin-bottom: -1.7143em;	// -24px
+			}
 
-		.field-label-vertical {
-			margin-bottom: 0.5rem;
-			line-height: 0.75rem;
-			font-size: 0.75rem;
-			color: $midgray2;
-		}
+			.field-label-vertical {
+				font-size: 0.75em;			// 12px
+				margin-bottom: 0.6667em;	// 8px
+				line-height: 1em;			// 12px
+				color: $midgray2;
+			}
 
-		.field-value-vertical {
-			line-height: 14px;
-			overflow: hidden;
-			text-overflow: ellipsis;
+			.field-value-vertical {
+				line-height: 1em;	// 14px
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
 		}
 
 		.service-items-listing.monster-table tbody td:not(.category-cell) {
@@ -661,17 +671,18 @@ $color-highlight: #dbdbde;
 
 			.column-title {
 				color: $woodsmoke;
-				font-size: 14px;
+				font-size: 0.875em;		// 14px
 				font-weight: 600;
-				line-height: 14px;
-				padding-bottom: 1.5rem;
+				line-height: 1em;		// 14px
+				padding-bottom: 1.7143em;	// 24px
 			}
 
 			.field-label-horizontal {
 				width: 57.1429%;
 
 				.iconography-text-right {
-					margin-left: 0.75rem;
+					// font-size: 14px;
+					margin-left: 0.8571em;	// 12px
 				}
 			}
 
@@ -748,7 +759,7 @@ $color-highlight: #dbdbde;
 		}
 
 		.app-list .app-item {
-			padding-bottom: 1rem;
+			padding-bottom: 1em;	// 14px
 
 			.app-icon {
 				padding: 0;
@@ -769,6 +780,7 @@ $color-highlight: #dbdbde;
 
 		@media print {
 			padding: 0;
+			font-size: 8pt;
 
 			.edit-step, .step-action-button {
 				display: none;

--- a/submodules/wizard/wizard.scss
+++ b/submodules/wizard/wizard.scss
@@ -663,6 +663,7 @@ $color-highlight: #dbdbde;
 		}
 
 		.field-value-vertical {
+			min-height: 1rem;
 			line-height: 14px;
 			overflow: hidden;
 			text-overflow: ellipsis;
@@ -800,6 +801,10 @@ $color-highlight: #dbdbde;
 			padding: 0;
 
 			.edit-step, .step-action-button {
+				display: none;
+			}
+
+			.app-list .app-item .app-icon {
 				display: none;
 			}
 

--- a/submodules/wizard/wizard.scss
+++ b/submodules/wizard/wizard.scss
@@ -799,8 +799,8 @@ $color-highlight: #dbdbde;
 				display: none;
 			}
 
-			.section-title {
-				page-break-after: avoid;
+			.print-nobreak {
+				page-break-inside: avoid;
 			}
 
 			// Some elements that use display:flex might be truncated on page breaks.

--- a/submodules/wizard/wizard.scss
+++ b/submodules/wizard/wizard.scss
@@ -1,8 +1,20 @@
 @import "../../../../css/partials/base";
 
-$media-size-small: "screen and (max-width : 736px)";
-$media-size-medium: "screen and (max-width : 980px)";
+$media-size-small: "(max-width : 736px)";
+$media-size-medium: "(max-width : 980px)";
 $color-highlight: #dbdbde;
+
+@mixin all-small {
+	@media all and (#{$media-size-small})  {
+		@content;
+	}
+}
+
+@mixin all-medium {
+	@media all and (#{$media-size-medium})  {
+		@content;
+	}
+}
 
 #navigation_wizard_wrapper .wizard-step {
 	padding: 2rem 1.5rem;
@@ -185,7 +197,7 @@ $color-highlight: #dbdbde;
 			width: 75%;
 		}
 
-		@media #{$media-size-medium} {
+		@include all-medium {
 			.flex-item-2 {
 				width: 100%;
 			}
@@ -203,7 +215,7 @@ $color-highlight: #dbdbde;
 			}
 		}
 
-		@media #{$media-size-small} {
+		@include all-small {
 			.flex-item-3 {
 				width: 100%;
 			}
@@ -509,7 +521,7 @@ $color-highlight: #dbdbde;
 						z-index: 10;
 					}
 
-					@media #{$media-size-medium} {
+					@include all-medium {
 						.monster-panel-text {
 							display: none;
 							left: 0;
@@ -518,7 +530,7 @@ $color-highlight: #dbdbde;
 						}
 					}
 
-					@media #{$media-size-small} {
+					@include all-small {
 						.monster-panel-text {
 							width: 100%;
 						}
@@ -537,7 +549,7 @@ $color-highlight: #dbdbde;
 			margin-left: 20%;
 			width: auto;
 
-			@media #{$media-size-medium} {
+			@include all-medium {
 				margin-left: 0;
 			}
 		}
@@ -681,14 +693,27 @@ $color-highlight: #dbdbde;
 			}
 
 
-			@media #{$media-size-medium} {
-				.field-label-horizontal, .field-value-horizontal {
-					width: 100%;
+			@include all-medium() {
+				.field-label-horizontal {
+					width: 66.67%;
+				}
+				.field-value-horizontal {
+					width: 33.33%;
+
+					.iconography-text {
+						display: none;
+					}
 				}
 			}
 		}
 
-		@media #{$media-size-small} {
+		@include all-medium {
+			.field-value-horizontal:not(.field-value-multiple) {
+				width: 50%;
+			}
+		}
+
+		@include all-small {
 			.field-group-column {
 				width: 100%;
 			}

--- a/submodules/wizard/wizard.scss
+++ b/submodules/wizard/wizard.scss
@@ -118,13 +118,11 @@ $color-highlight: #dbdbde;
 		color: $woodsmoke;
 	}
 
-	.step-action-button {
-		width: 2.375rem;
+	.monster-button.step-action {
+		min-width: 2.375rem;	// To override monster-button's default min-width
 		height: 2.375rem;
 		margin-left: 0.75rem;
-		background: linear-gradient(-180deg, $white 0%, $athens-gray 100%);
-		border: 1px solid $french-gray2;
-		border-radius: 2px;
+		padding: 0.5rem;
 	}
 
 	.section-title {
@@ -801,7 +799,7 @@ $color-highlight: #dbdbde;
 			padding: 0;
 
 			.edit-step,
-			.step-action-button,
+			.monster-button,
 			.password-toggle-label,
 			.password-text,
 			.app-list .app-item .app-icon {

--- a/submodules/wizard/wizard.scss
+++ b/submodules/wizard/wizard.scss
@@ -106,6 +106,15 @@ $color-highlight: #dbdbde;
 		color: $woodsmoke;
 	}
 
+	.step-action-button {
+		width: 2.375rem;
+		height: 2.375rem;
+		margin-left: 0.75rem;
+		background: linear-gradient(-180deg, $white 0%, $athens-gray 100%);
+		border: 1px solid $french-gray2;
+		border-radius: 2px;
+	}
+
 	.section-title {
 		margin-top: 1rem;
 		margin-bottom: 1.5rem;

--- a/submodules/wizard/wizard.scss
+++ b/submodules/wizard/wizard.scss
@@ -4,12 +4,7 @@ $media-size-small: "screen and (max-width : 736px)";
 $media-size-medium: "screen and (max-width : 980px)";
 $color-highlight: #dbdbde;
 
-// Some lengths are specified in em, to be able to resize it for printing by only changing the
-// font size of the step's container
-// Beware that the em size for an element is proportional to its font-size, or its parent font size
-// which means that if the font-size:8px, then a margin:0.5em will be equivalent to 4px
 #navigation_wizard_wrapper .wizard-step {
-	font-size: 1rem;	// Set base font size for container
 	padding: 2rem 1.5rem;
 
 	.iconography-small {
@@ -105,9 +100,9 @@ $color-highlight: #dbdbde;
 	}
 
 	.step-title {
-		padding-bottom: 1.0434em;	// 24px
-		font-size: 1.4375em;		// 23px
-		line-height: 1em;			// 23px
+		padding-bottom: 1.5rem;
+		font-size: 23px;
+		line-height: 1.875rem;
 		color: $woodsmoke;
 	}
 
@@ -121,12 +116,12 @@ $color-highlight: #dbdbde;
 	}
 
 	.section-title {
-		margin-top: 1em;		// 16px
-		margin-bottom: 1.5em;	// 24px
-		padding-bottom: 0.75em;	// 12px
+		margin-top: 1rem;
+		margin-bottom: 1.5rem;
+		padding-bottom: 0.75rem;
 		border-bottom: solid 1px $french-gray2;
-		line-height: 1em;		// 16px
-		font-size: 1em;			// 16px
+		line-height: 1rem;
+		font-size: 1rem;
 		font-weight: 600;
 		color: $woodsmoke;
 
@@ -138,7 +133,7 @@ $color-highlight: #dbdbde;
 			}
 
 			.iconography-medium {
-				margin-top: -0.25em;	// -4px
+				margin-top: -0.25rem;
 			}
 		}
 	}
@@ -624,42 +619,37 @@ $color-highlight: #dbdbde;
 			font-weight: 600;
 
 			.iconography-medium {
-				margin-right: 0.5em;	// 8px
-				width: 1em;				// 16px
-				height: 1em;			// 16px
+				margin-right: 0.5rem;
 			}
 		}
 
 		.field-label-horizontal, .field-value-horizontal {
-			font-size: 0.875em;			// 14px
-			margin-top: -0.2857em;		// -4px
-			margin-bottom: 0.2857em;	// 4px
-			padding-bottom: 1.1429em;	// 16px
-			line-height: 1.4286em;		// 20px
+			margin-top: -0.25rem;
+			margin-bottom: 0.25rem;
+			padding-bottom: 1rem;
+			line-height: 21px;
 		}
 
 		.field-label-horizontal {
 			color: $woodsmoke;
-			letter-spacing: 0;
+			letter-spacing: 0px;
 		}
 
-		.field-value-horizontal {
-			.flex-row-container:last-child {
-				margin-bottom: -1.7143em;	// -24px
-			}
+		.field-value-horizontal .flex-row-container:last-child {
+			margin-bottom: -1.5rem;
+		}
 
-			.field-label-vertical {
-				font-size: 0.75em;			// 12px
-				margin-bottom: 0.6667em;	// 8px
-				line-height: 1em;			// 12px
-				color: $midgray2;
-			}
+		.field-label-vertical {
+			margin-bottom: 0.5rem;
+			line-height: 0.75rem;
+			font-size: 0.75rem;
+			color: $midgray2;
+		}
 
-			.field-value-vertical {
-				line-height: 1em;	// 14px
-				overflow: hidden;
-				text-overflow: ellipsis;
-			}
+		.field-value-vertical {
+			line-height: 14px;
+			overflow: hidden;
+			text-overflow: ellipsis;
 		}
 
 		.service-items-listing.monster-table tbody td:not(.category-cell) {
@@ -671,18 +661,17 @@ $color-highlight: #dbdbde;
 
 			.column-title {
 				color: $woodsmoke;
-				font-size: 0.875em;		// 14px
+				font-size: 14px;
 				font-weight: 600;
-				line-height: 1em;		// 14px
-				padding-bottom: 1.7143em;	// 24px
+				line-height: 14px;
+				padding-bottom: 1.5rem;
 			}
 
 			.field-label-horizontal {
 				width: 57.1429%;
 
 				.iconography-text-right {
-					// font-size: 14px;
-					margin-left: 0.8571em;	// 12px
+					margin-left: 0.75rem;
 				}
 			}
 
@@ -759,7 +748,7 @@ $color-highlight: #dbdbde;
 		}
 
 		.app-list .app-item {
-			padding-bottom: 1em;	// 14px
+			padding-bottom: 1rem;
 
 			.app-icon {
 				padding: 0;
@@ -780,7 +769,6 @@ $color-highlight: #dbdbde;
 
 		@media print {
 			padding: 0;
-			font-size: 8pt;
 
 			.edit-step, .step-action-button {
 				display: none;

--- a/submodules/wizard/wizard.scss
+++ b/submodules/wizard/wizard.scss
@@ -1,7 +1,7 @@
 @import "../../../../css/partials/base";
 
-$media-size-small: "all and (max-width : 736px)";
-$media-size-medium: "all and (max-width : 980px)";
+$media-size-small: "screen and (max-width : 736px)";
+$media-size-medium: "screen and (max-width : 980px)";
 $color-highlight: #dbdbde;
 
 #navigation_wizard_wrapper .wizard-step {
@@ -760,6 +760,29 @@ $color-highlight: #dbdbde;
 				overflow: hidden;
 				white-space: nowrap;
 				text-overflow: ellipsis;
+			}
+		}
+
+		#service_plan_aggregate {
+			margin-left: auto;
+		}
+
+		@media print {
+			padding: 0;
+
+			.edit-step, .step-action-button {
+				display: none;
+			}
+
+			.section-title {
+				page-break-after: avoid;
+			}
+
+			// Some elements that use display:flex might be truncated on page breaks.
+			// This class sets them to display:block to avoid that behavior on print
+			// See https://stackoverflow.com/a/39228298/806975
+			.print-block {
+				display: block;
 			}
 		}
 	}

--- a/submodules/wizard/wizard.scss
+++ b/submodules/wizard/wizard.scss
@@ -4,14 +4,14 @@ $media-size-small: "(max-width : 736px)";
 $media-size-medium: "(max-width : 980px)";
 $color-highlight: #dbdbde;
 
-@mixin all-small {
+@mixin media-small {
 	@media all and (#{$media-size-small})  {
 		@content;
 	}
 }
 
-@mixin all-medium {
-	@media all and (#{$media-size-medium})  {
+@mixin media-medium-or-print {
+	@media all and (#{$media-size-medium}), print  {
 		@content;
 	}
 }
@@ -197,7 +197,7 @@ $color-highlight: #dbdbde;
 			width: 75%;
 		}
 
-		@include all-medium {
+		@include media-medium-or-print {
 			.flex-item-2 {
 				width: 100%;
 			}
@@ -215,7 +215,7 @@ $color-highlight: #dbdbde;
 			}
 		}
 
-		@include all-small {
+		@include media-small {
 			.flex-item-3 {
 				width: 100%;
 			}
@@ -521,7 +521,7 @@ $color-highlight: #dbdbde;
 						z-index: 10;
 					}
 
-					@include all-medium {
+					@include media-medium-or-print {
 						.monster-panel-text {
 							display: none;
 							left: 0;
@@ -530,7 +530,7 @@ $color-highlight: #dbdbde;
 						}
 					}
 
-					@include all-small {
+					@include media-small {
 						.monster-panel-text {
 							width: 100%;
 						}
@@ -549,7 +549,7 @@ $color-highlight: #dbdbde;
 			margin-left: 20%;
 			width: auto;
 
-			@include all-medium {
+			@include media-medium-or-print {
 				margin-left: 0;
 			}
 		}
@@ -693,7 +693,7 @@ $color-highlight: #dbdbde;
 			}
 
 
-			@include all-medium() {
+			@include media-medium-or-print() {
 				.field-label-horizontal {
 					width: 66.67%;
 				}
@@ -707,13 +707,13 @@ $color-highlight: #dbdbde;
 			}
 		}
 
-		@include all-medium {
+		@include media-medium-or-print {
 			.field-value-horizontal:not(.field-value-multiple) {
 				width: 50%;
 			}
 		}
 
-		@include all-small {
+		@include media-small {
 			.field-group-column {
 				width: 100%;
 			}

--- a/submodules/wizard/wizard.scss
+++ b/submodules/wizard/wizard.scss
@@ -800,12 +800,16 @@ $color-highlight: #dbdbde;
 		@media print {
 			padding: 0;
 
-			.edit-step, .step-action-button {
+			.edit-step,
+			.step-action-button,
+			.password-toggle-label,
+			.password-text,
+			.app-list .app-item .app-icon {
 				display: none;
 			}
 
-			.app-list .app-item .app-icon {
-				display: none;
+			.password-field .password-value .password-mask {
+				display: inline;
 			}
 
 			.print-nobreak {

--- a/submodules/wizard/wizard.scss
+++ b/submodules/wizard/wizard.scss
@@ -448,6 +448,10 @@ $color-highlight: #dbdbde;
 				margin-top: -3px;
 			}
 		}
+
+		#service_plan_aggregate {
+			margin-top: 0.25rem;
+		}
 	}
 
 	&#step_credit_balance_and_features {
@@ -803,9 +807,9 @@ $color-highlight: #dbdbde;
 				page-break-inside: avoid;
 			}
 
-			// Some elements that use display:flex might be truncated on page breaks.
-			// This class sets them to display:block to avoid that behavior on print
-			// See https://stackoverflow.com/a/39228298/806975
+			// Some elements that use display:flex might be truncated on page breaks in Firefox.
+			// This class sets them to display:block to avoid that behavior on print.
+			// See https://stackoverflow.com/a/45440750/806975
 			.print-block {
 				display: block;
 			}


### PR DESCRIPTION
* PDFMake library was discarded in favor of HTML/CSS and the `print` media type, to avoid building the page again in JSON for the PDF/print view. This because the print functionality is expected to be added to all wizards, and each wizard would have to do the same to render the document.
* The idea to use `em` instead of `rem` units to be able to manage the print size was discarded, because it was difficult to calculate the sizes for nested elements, as they depend on their predecessor's font sizes.
* The black color and lack of images on printing is due to Bootstrap preset styles, to reduce the ink usage. I decided to leave it that way, to avoid overloading the printed document with colors, and also because there is no design for printed documents.
* I considered to add a whitelabel header to the pages similar to the one used in the invoices document, but gave up because the only way that I found requires to modify the structure of the wizard itself, by wrapping it inside a `table` element: https://next.plnkr.co/edit/lWk6Yd?preview
It is not difficult, but will make the HTML layout less semantic.
* Additionally, some tweaks and fixes were made to the review step and the service items listing.