### PR TITLE
MACT-57: Fix duplicated plan items and zero rates

### DIFF
--- a/submodules/serviceItemsListing/views/layout.html
+++ b/submodules/serviceItemsListing/views/layout.html
@@ -22,9 +22,7 @@
 						{{#compare rate.value "===" null}}
 							<span>--</span>
 						{{else}}
-							{{#if rate.value}}
-								{{formatPrice rate.value 2}}
-							{{/if}}
+							{{formatPrice rate.value 2}}
 						{{/compare}}
 						{{#if rate.isCascade}}
 							<span class="iconography" title="{{@root.i18n.accountsApp.serviceItemsListing.labels.cascadeTooltip}}" data-toggle="tooltip">


### PR DESCRIPTION
Second pass on MACT-57, to:
* Avoid duplicating plan items by getting their details only from the invoice plan.
* Display zero-valued rates.

4.3 -> #115