### PR TITLE
MACT-71: Fix insertTemplate usage compatibility issue

### DIFF
--- a/submodules/wizard/wizard.js
+++ b/submodules/wizard/wizard.js
@@ -133,7 +133,7 @@ define(function(require) {
 			});
 
 			// Show loading template while loading data
-			monster.ui.insertTemplate($container, null, {
+			monster.ui.insertTemplate($container, function() { }, {
 				hasBackground: false
 			});
 


### PR DESCRIPTION
Pass empty callback to `insertTemplate` function, to make it compatible with `monster-ui@4.3.x`