### PR TITLE
MACT-70: Check HTTP code on reseller account response

### DIFF
--- a/submodules/wizard/wizard.js
+++ b/submodules/wizard/wizard.js
@@ -168,7 +168,8 @@ define(function(require) {
 						generateError: false,
 						callback: function(err) {
 							var status = _.get(err, 'status'),
-								isResellerUnavailable = _.includes([ 403, 404 ], status);
+								httpStatus = _.get(err, 'httpErrorStatus', status),
+								isResellerUnavailable = _.includes([ 403, 404 ], httpStatus);
 
 							if (!isResellerUnavailable) {
 								self.wizardSetStore('resellerAccountId', resellerAccountId);


### PR DESCRIPTION
It seems that some versions of the Kazoo API return the `content-type` header in the error responses, while some don't. This causes the `parsedError` object returned to the error callback on the `callApi` method to differ. One of these differences is the property containing the HTTP status code obtained in the API response: it may be `httpErrorStatus` or `status` (see https://github.com/2600hz/monster-ui/blob/master/src/js/lib/jquery.kazoosdk.js#L725).

The change in this PR is to use `httpErrorStatus` over `status`, if the former is present.