### PR TITLE
[5.4] MACT-104: Add checkbox to enable MFA from the 'Accounts' page (#206)

### DIFF
--- a/i18n/de-DE.json
+++ b/i18n/de-DE.json
@@ -24,6 +24,22 @@
 	"accountId": "Account-ID",
 	"accountName": "Account-Name",
 	"accountRealm": "Account-Bereich",
+	"multiFactorAuthentication": {
+		"label": "Multi-Factor Authentication",
+		"name": "Enable Multi-factor authentication (MFA)",
+		"description": "Enabling multi-factor authentication (MFA) strengthens the security of your entire account and all users within it.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"toastr": {
+			"success": "Multi-factor authentication updated successfully!",
+			"error": "Multi-factor authentication cannot be disabled because at least 1 number is enabled for messaging."
+		},
+		"confirmDialog": {
+			"title": "Are you sure you want to enable MFA?",
+			"description": "Multi-factor authentication (MFA) will be enabled to your entire account. This requirement ensures ongoing compliance and secure access to Messaging features.",
+			"confirmButton": "Enable MFA"
+		}
+	},
 	"accountTimezone": "Zeitzone",
 	"accountLanguage": "Sprache",
 	"accountTimezoneTitle": "Zeitzone und Sprache",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -24,6 +24,22 @@
 	"accountId": "Account ID",
 	"accountName": "Account Name",
 	"accountRealm": "Account Realm",
+	"multiFactorAuthentication": {
+		"label": "Multi-Factor Authentication",
+		"name": "Enable Multi-factor authentication (MFA)",
+		"description": "Enabling multi-factor authentication (MFA) strengthens the security of your entire account and all users within it.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"toastr": {
+			"success": "Multi-factor authentication updated successfully!",
+			"error": "Multi-factor authentication cannot be disabled because at least 1 number is enabled for messaging."
+		},
+		"confirmDialog": {
+			"title": "Are you sure you want to enable MFA?",
+			"description": "Multi-factor authentication (MFA) will be enabled to your entire account. This requirement ensures ongoing compliance and secure access to Messaging features.",
+			"confirmButton": "Enable MFA"
+		}
+	},
 	"accountTimezone": "Timezone",
 	"accountLanguage": "Language",
 	"accountTimezoneTitle": "Timezone & Language",

--- a/i18n/es-ES.json
+++ b/i18n/es-ES.json
@@ -24,6 +24,22 @@
 	"accountId": "Identificación de la cuenta",
 	"accountName": "Nombre de la cuenta",
 	"accountRealm": "Reino de cuenta",
+	"multiFactorAuthentication": {
+		"label": "Multi-Factor Authentication",
+		"name": "Enable Multi-factor authentication (MFA)",
+		"description": "Enabling multi-factor authentication (MFA) strengthens the security of your entire account and all users within it.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"toastr": {
+			"success": "Multi-factor authentication updated successfully!",
+			"error": "Multi-factor authentication cannot be disabled because at least 1 number is enabled for messaging."
+		},
+		"confirmDialog": {
+			"title": "Are you sure you want to enable MFA?",
+			"description": "Multi-factor authentication (MFA) will be enabled to your entire account. This requirement ensures ongoing compliance and secure access to Messaging features.",
+			"confirmButton": "Enable MFA"
+		}
+	},
 	"accountTimezone": "Zona de Horaria",
 	"accountLanguage": "Idioma",
 	"accountTimezoneTitle": "Idioma y Zona horaria",

--- a/i18n/fr-FR.json
+++ b/i18n/fr-FR.json
@@ -24,6 +24,22 @@
 	"accountId": "ID du compte",
 	"accountName": "Nom du compte",
 	"accountRealm": "Royaume du compte",
+	"multiFactorAuthentication": {
+		"label": "Multi-Factor Authentication",
+		"name": "Enable Multi-factor authentication (MFA)",
+		"description": "Enabling multi-factor authentication (MFA) strengthens the security of your entire account and all users within it.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"toastr": {
+			"success": "Multi-factor authentication updated successfully!",
+			"error": "Multi-factor authentication cannot be disabled because at least 1 number is enabled for messaging."
+		},
+		"confirmDialog": {
+			"title": "Are you sure you want to enable MFA?",
+			"description": "Multi-factor authentication (MFA) will be enabled to your entire account. This requirement ensures ongoing compliance and secure access to Messaging features.",
+			"confirmButton": "Enable MFA"
+		}
+	},
 	"accountTimezone": "Fuseau horaire",
 	"accountLanguage": "Langage",
 	"accountTimezoneTitle": "Fuseau Horare & Langage",

--- a/i18n/ru-RU.json
+++ b/i18n/ru-RU.json
@@ -24,6 +24,22 @@
 	"accountId": "ID учётной записи клиента",
 	"accountName": "Название клиента",
 	"accountRealm": "SIP-домен (realm)",
+	"multiFactorAuthentication": {
+		"label": "Multi-Factor Authentication",
+		"name": "Enable Multi-factor authentication (MFA)",
+		"description": "Enabling multi-factor authentication (MFA) strengthens the security of your entire account and all users within it.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"toastr": {
+			"success": "Multi-factor authentication updated successfully!",
+			"error": "Multi-factor authentication cannot be disabled because at least 1 number is enabled for messaging."
+		},
+		"confirmDialog": {
+			"title": "Are you sure you want to enable MFA?",
+			"description": "Multi-factor authentication (MFA) will be enabled to your entire account. This requirement ensures ongoing compliance and secure access to Messaging features.",
+			"confirmButton": "Enable MFA"
+		}
+	},
 	"accountTimezone": "Часовой пояс",
 	"accountLanguage": "Язык",
 	"accountTimezoneTitle": "Часовой пояс и язык",

--- a/style/app.scss
+++ b/style/app.scss
@@ -285,6 +285,14 @@
 	margin-left: 20px;
 }
 
+#accounts_manager_view .main-content .list-settings .settings-item .mfa-description {
+	font-size: 12px;
+}
+
+#accounts_manager_view .main-content .list-settings .settings-item .mfa-enabled {
+	color: #3E4CAB;
+}
+
 #accounts_manager_view .main-content .list-settings .settings-item .settings-link .description {
 	display: inline-block;
 	font-weight: 600;

--- a/views/edit.html
+++ b/views/edit.html
@@ -178,6 +178,47 @@
 							</div>
 						</div>
 					</li>
+					<!-- Multi-Factor Authentication -->
+					<li class="settings-item {{#unless account.enabled}}disabled{{/unless}}" data-name="accountsmanager_mfa">
+						<a class="settings-link clearfix">
+							<span class="title">{{ i18n.multiFactorAuthentication.label }}</span>
+							<span class="description">
+								{{#if isMFAEnabled }}
+									<span class="mfa-enabled">{{ i18n.multiFactorAuthentication.enabled }}</span>
+								{{else}}
+									{{ i18n.multiFactorAuthentication.disabled }}
+								{{/if}}
+							</span>
+							<span class="update">
+								<i class="fa fa-cog icon-small"></i>
+								<span class="text">{{ i18n.editSetting }}</span>
+							</span>
+							<span class="changes-saved">{{ i18n.changesSaved }}</span>
+						</a>
+						<div class="settings-item-content">
+							<div class="row-fluid">
+								<div class="span12">
+									<form class="form-horizontal" id="form_accountsmanager_mfa">
+										<div class="control-group">
+											<label class="control-label" for="accountsmanager_mfa">{{ i18n.multiFactorAuthentication.label }}</label>
+											<div class="controls">
+												{{#monsterCheckbox i18n.multiFactorAuthentication.name}}
+													<input type="checkbox" name="mfa" {{#if isMFAEnabled}}checked{{/if}}>
+												{{/monsterCheckbox}}
+												<div class="mfa-description">{{ i18n.multiFactorAuthentication.description }}</div>
+											</div>
+										</div>
+										<div class="action-group clearfix">
+											<div class="action-bar">
+												<button type="button" class="cancel monster-button">{{ i18n.cancel }}</button>
+												<button type="submit" class="monster-button-success enableMFA" data-field="accountsmanager_mfa">{{ i18n.saveChanges }}</button>
+											</div>
+										</div>
+									</form>
+								</div>
+							</div>
+						</div>
+					</li>
 					<!-- Account admins -->
 					<li class="settings-item {{#unless account.enabled}}disabled{{/unless}}" data-name="accountsmanager_account_admins">
 						<a class="settings-link clearfix">


### PR DESCRIPTION
* MACT-104: Add checkbox to enable MFA from the 'Accounts' page

* Add dialog to confirm enabling MFA

* Add condition to not allow to turn MFA off if carrier is TIO and has sms/mms enabled

* Add fixes based on code review